### PR TITLE
Add more startup logging

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -70,8 +70,7 @@ func New(cfg config.Config) (*Server, error) {
 		keyDataMap: make(map[pgproto3.BackendKeyData]*ClientConn),
 	}
 
-	s.logger.Info("Initializing server...")
-	s.logger.Info("Initializing database proxy listener...", logr.String("listen-address", cfg.ListenAddress))
+	s.logger.Info("Initializing server...", logr.String("listen-address", cfg.ListenAddress))
 	l, err := net.Listen("tcp", s.cfg.ListenAddress)
 	if err != nil {
 		return nil, fmt.Errorf("error trying to listen on %s: %w", s.cfg.ListenAddress, err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -70,7 +70,8 @@ func New(cfg config.Config) (*Server, error) {
 		keyDataMap: make(map[pgproto3.BackendKeyData]*ClientConn),
 	}
 
-	s.logger.Info("Initializing server...")
+	s.logger.Info("Initializing server...", logr.String("log-level", cfg.LogSettings.Level), logr.Bool("json-logging", cfg.LogSettings.Json))
+	s.logger.Info("Initializing database proxy listener...", logr.String("listen-address", cfg.ListenAddress))
 	l, err := net.Listen("tcp", s.cfg.ListenAddress)
 	if err != nil {
 		return nil, fmt.Errorf("error trying to listen on %s: %w", s.cfg.ListenAddress, err)
@@ -106,6 +107,7 @@ func New(cfg config.Config) (*Server, error) {
 		router.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
 		s.metricsWg.Add(1)
+		s.logger.Info("Initializing metrics...", logr.String("metrics-address", cfg.MetricsAddress))
 		go func() {
 			defer s.metricsWg.Done()
 			err2 := s.metricsSrv.ListenAndServe()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -70,7 +70,7 @@ func New(cfg config.Config) (*Server, error) {
 		keyDataMap: make(map[pgproto3.BackendKeyData]*ClientConn),
 	}
 
-	s.logger.Info("Initializing server...", logr.String("log-level", cfg.LogSettings.Level), logr.Bool("json-logging", cfg.LogSettings.Json))
+	s.logger.Info("Initializing server...")
 	s.logger.Info("Initializing database proxy listener...", logr.String("listen-address", cfg.ListenAddress))
 	l, err := net.Listen("tcp", s.cfg.ListenAddress)
 	if err != nil {


### PR DESCRIPTION
This change increases server startup logging by reporting a few config values that may be valuable for troubleshooting.

Fixes https://mattermost.atlassian.net/browse/MM-49620